### PR TITLE
Drop Freenode footnote because what Freenode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,53 +1,36 @@
 <!DOCTYPE html>
 <html lang="sl">
-    <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Vodič po #fri</title>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>Vodič po #fri</title>
 
-        <style>
-            body { margin: 2em auto; max-width: 50em; }
-            p { hyphens: auto; line-height: 1.6em; margin: 0 0 1em; }
-            h1 { margin-bottom: 0.5em; }
-            sup { font-size: 0.8em; line-height: 1em; }
-        </style>
-    </head>
-    <body>
-        <section>
-            <h1>#fri</h1>
+<style>
+    body { margin: 2em auto; max-width: 50em; }
+    p { hyphens: auto; line-height: 1.6em; margin: 0 0 1em; }
+    h1 { margin-bottom: 0.5em; }
+    sup { font-size: 0.8em; line-height: 1em; }
+</style>
 
-            <p>
-                TL;DR Pojdi <a href="https://web.libera.chat/#fri">sem</a>, izberi vzdevek, reci živjo in počakaj. :)
-            </p>
-            <p>
-                <abbr title="Internet Relay Chat">IRC</abbr> je protokol za <del>posredovano medmrežno takojšnjo neposredno komunikacijo</del> klepet, star štiri internetna tisočletja. Uporabljamo ga skoraj povsem, a ne docela drugače kot Snapchat. Glavna odlika IRCa so <em>kanali</em>, na katerih včasih klepeta več kot tisoč uporabnikov. FRIjevske entitete skupaj zabijamo čas na kanalu #fri, kjer včasih klepeta več kot en uporabnik. Tam običajno ždi tudi fribot, prva prijateljska nadčloveška umetna inteligenca<sup><a href="#footnote-ai" id="ref-ai">1</a></sup>.
-            </p>
-            <p>
-                Kanalu »hashtag fri« se pridružiš tako, da namestiš <a href="https://hexchat.github.io/">enega</a> <a href="https://quassel-irc.org/">od</a> <a href="https://smuxi.im/">mnogih</a> <a href="https://konversation.kde.org/">odjemalcev</a><sup><a href="#footnote-clients" id="ref-clients">2</a></sup>, izbereš strežnik irc.libera.chat,<sup><a href="#ref-tls">3</a></sup> kanal #fri in svoj vzdevek ter ob polni luni žrtvuješ dvoglavo kozo. Omrežje <a href="https://libera.chat/">Libera Chat</a> ne zahteva (a dopušča) registracije: izbereš si vzdevek in tipkaš.
-            </p>
-            <p>
-                Komunikacija na IRCu pokriva območje med sporočilom SMS in Pony Express. Zasebni pogovori dostikrat potekajo bolj ali manj v živo, na kanalih pa so uporabniki pogosto <del>mrtvi</del> <abbr title="away from keyboard">AFK</abbr>. Med sporočili zato lahko mine več minut, ur ali dni. To je nerodno za uporabnike klicnih modemov in pametnih telefonov, saj strežniki ne beležijo klepetov.
-            </p>
-            <p>
-                Pomaga nam lahko t.i. vratar, t.j. program, ki ga namestiš na svoj osebni strežnik, da visi na kanalu v tvojem imenu. Priljubljene rešitve vključujejo <a href="https://thelounge.chat/">The Lounge</a>, <a href="https://znc.in/">ZNC</a> in <a href="https://www.gnu.org/software/screen/">screen</a>+<a href="https://irssi.org/">irssi</a> oziroma <a href="https://tmux.github.io/">tmux</a>+<a href="https://weechat.org/">weechat</a> za hipsterje. Če še nimaš svojega strežnika, se oglasi na #fri in ti bomo pomagali.
-            </p>
-        </section>
-        <hr>
-        <section>
-            <ol>
-                <li id="footnote-ai">
-                    <sup><a href="#ref-ai">^</a></sup> V razvoju.
-                </li>
-                <li id="footnote-clients">
-                    <sup><a href="#ref-clients">^</a></sup>
-                    <a href="http://bitchx.org/">Zadnje</a> <a href="http://chatzilla.hacksrus.com/">raziskave</a> <a href="https://git.savannah.gnu.org/gitweb/?p=erc.git">kažejo</a>, <a href="https://irssi.org/">da</a> <a href="http://www.eterna.com.au/ircii/">za</a> <a href="https://pidgin.im/">vsakega</a> <a href="https://weechat.org/">programerja</a> <a href="https://github.com/jorgenschaefer/circe">obstaja</a> <a href="http://epicsol.org/">vsaj</a> <a href="https://wiki.gnome.org/Apps/Polari">sedem</a> <a href="http://rhapsody.sourceforge.net/">odjemalcev</a> <a href="https://xaric.org/">za</a> <a href="http://www.zenirc.org/">IRC</a>.
-                </li>
-                <li id="footnote-tls">
-                    <sup><a href="#ref-tls">^</a></sup> Uporabi TLS ali pa te M477 ne bo imel rad.
-                </li>
-                <li id="footnote-freenode">
-                    <sup><a href="#ref-freenode">^</a></sup> Zaradi nedavnih sprememb v politiki omrežja Freenode, se je #fri premaknil na Libera Chat.
-                </li>
-            </ol>
-        </section>
-    </body>
-</html>
+<h1>#fri</h1>
+
+<p>TL;DR Pojdi <a href="https://web.libera.chat/#fri">sem</a>, izberi vzdevek, reci živjo in počakaj. :)
+
+<p><abbr title="Internet Relay Chat">IRC</abbr> je protokol za <del>posredovano medmrežno takojšnjo neposredno komunikacijo</del> klepet, star štiri internetna tisočletja. Uporabljamo ga skoraj povsem, a ne docela drugače kot Snapchat. Glavna odlika IRCa so <em>kanali</em>, na katerih včasih klepeta več kot tisoč uporabnikov. FRIjevske entitete skupaj zabijamo čas na kanalu #fri, kjer včasih klepeta več kot en uporabnik. Tam običajno ždi tudi fribot, prva prijateljska nadčloveška umetna inteligenca<sup><a href="#note-ai" id="ref-ai">1</a></sup>.
+
+<p>Kanalu »hashtag fri« se pridružiš tako, da namestiš <a href="https://hexchat.github.io/">enega</a> <a href="https://quassel-irc.org/">od</a> <a href="https://smuxi.im/">mnogih</a> <a href="https://konversation.kde.org/">odjemalcev</a><sup><a href="#note-clients" id="ref-clients">2</a></sup>, izbereš strežnik irc.libera.chat<sup><a href="#note-tls" id="ref-tls">3</a></sup>, kanal #fri in svoj vzdevek ter ob polni luni žrtvuješ dvoglavo kozo. Omrežje <a href="https://libera.chat/">Libera Chat</a> ne zahteva (a dopušča) registracije: izbereš si vzdevek in tipkaš.
+
+<p>Komunikacija na IRCu pokriva območje med sporočilom SMS in Pony Express. Zasebni pogovori dostikrat potekajo bolj ali manj v živo, na kanalih pa so uporabniki pogosto <del>mrtvi</del> <abbr title="away from keyboard">AFK</abbr>. Med sporočili zato lahko mine več minut, ur ali dni. To je nerodno za uporabnike klicnih modemov in pametnih telefonov, saj strežniki ne beležijo klepetov.
+
+<p>Pomaga nam lahko t.i. vratar, t.j. program, ki ga namestiš na svoj osebni strežnik, da visi na kanalu v tvojem imenu. Priljubljene rešitve vključujejo <a href="https://thelounge.chat/">The Lounge</a>, <a href="https://znc.in/">ZNC</a> in <a href="https://www.gnu.org/software/screen/">screen</a>+<a href="https://irssi.org/">irssi</a> oziroma <a href="https://tmux.github.io/">tmux</a>+<a href="https://weechat.org/">weechat</a> za hipsterje. Če še nimaš svojega strežnika, se oglasi na #fri in ti bomo pomagali.
+
+<hr>
+
+<ol>
+<li id="note-ai"><sup><a href="#ref-ai">^</a></sup>
+V razvoju.
+
+<li id="note-clients"><sup><a href="#ref-clients">^</a></sup>
+<a href="http://bitchx.org/">Zadnje</a> <a href="http://chatzilla.hacksrus.com/">raziskave</a> <a href="https://git.savannah.gnu.org/gitweb/?p=erc.git">kažejo</a>, <a href="https://irssi.org/">da</a> <a href="http://www.eterna.com.au/ircii/">za</a> <a href="https://pidgin.im/">vsakega</a> <a href="https://weechat.org/">programerja</a> <a href="https://github.com/jorgenschaefer/circe">obstaja</a> <a href="http://epicsol.org/">vsaj</a> <a href="https://wiki.gnome.org/Apps/Polari">sedem</a> <a href="http://rhapsody.sourceforge.net/">odjemalcev</a> <a href="https://xaric.org/">za</a> <a href="http://www.zenirc.org/">IRC</a>.
+
+<li id="note-tls"><sup><a href="#ref-tls">^</a></sup>
+Uporabi TLS ali pa te M477 ne bo imel rad. Poleg tega #fri ne dovoli nešifriranih povezav.
+</ol>


### PR DESCRIPTION
Also simplify HTML and note the TLS now‐requirement.